### PR TITLE
Fix setting client config field

### DIFF
--- a/methods/client.go
+++ b/methods/client.go
@@ -229,7 +229,6 @@ func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
 
 func (c *Client) MakeResponse(request *http.Request, response interface{}) (*structure.VError, error) {
 	resp, err := c.Do(request, nil)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -244,9 +243,11 @@ func (c *Client) MakeResponse(request *http.Request, response interface{}) (*str
 			}()
 			return nil, nil
 		} else {
+			resp.Body.Close()
 			return nil, fmt.Errorf("could not cast the io.Reader param type")
 		}
 	}
+	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/methods/client.go
+++ b/methods/client.go
@@ -93,6 +93,7 @@ func NewClient(config *config.Config) (*Client, error) {
 		client:  config.HTTPClient,
 		baseURL: parsedBaseURL,
 		keyPair: keyPair,
+		config:  config,
 	}
 
 	c.Queues = &QueuesService{c}


### PR DESCRIPTION
Fixed:
* Fix panic during token reissue by setting config field in client
* Fix body close in case of handling octet-stream response